### PR TITLE
Use Gson for JSON encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As an illustration, consider the following set of images.
 
 - cinema-show-source (folder - ignored by `git`)
   - 1st-show (folder)
-    - meta.yaml
+    - meta.json
       - showName = "Falling down"
       - blocksX = 5
       - frameTime = 25
@@ -46,7 +46,7 @@ As an illustration, consider the following set of images.
     - Image 1.png
     - Image 2.jpg
   - something-else (folder)
-    - meta.yaml
+    - meta.json
       - showName = "Getting up"
       - blocksY = 3
       - frameTime = 10
@@ -57,7 +57,7 @@ As an illustration, consider the following set of images.
     - Image D.png
 
 Each folder defines a separate show (a set of image files) for which a different set of resources
-will be generated. Along with the set of image files there is `meta.yaml` that defines various
+will be generated. Along with the set of image files there is `meta.json` that defines various
 properties. For instance, the `assignToBlock` parameter defines which screen block the show will be
 assigned to.
 
@@ -74,9 +74,9 @@ For folder "1st-show":
   animation frame rate as `frameTime` (defined in ticks).
 - The images are outputted to the `generatedTextures` resource folder in the 
   `assets.cinemashow.textures.block` package.
-- The `meta.yaml` is written to `assets.cinemashow` as `{block name}.yaml` to be available to the
-  code during resource generation (see above) and in-game. Additionally `blocks2ndAxis` is written
-  to this file (in this case `blocksX`).
+- The `meta.json` is written to `assets.cinemashow` as `{block name}.json` to be available to the
+  code during resource generation (see above) and in-game. Additionally `blocksY` is written to
+  this file.
 
 Note:
 
@@ -84,6 +84,10 @@ Note:
   different axis.
 - The lexicographic order of the image files will give the play order. The image file name is not
   used for anything else.
+- If `frameTime` isn't given,
+  [a default is assumed](https://github.com/msb/cinema-show/blob/main/src/main/java/uk/me/msb/cinemashow/ShowProperties.java#L29).
+- If neither `blocksX` or `blocksY` is given,
+  [`blocksX` is set to the maximum value](https://github.com/msb/cinema-show/blob/main/src/main/java/uk/me/msb/cinemashow/ShowProperties.java#L39).
 
 ## Running
 
@@ -100,8 +104,6 @@ Note:
   dependencies directly in the MOD jar. This feel a bit hacky
 - Gradle config: It isn't clear to me how to generate separate data packs
 - MC isn't optimised for dealing with state `Property` objects with a large number of possible values (ScreenStateProperty).
-- I think everything except `assignToBlock` in `meta.yaml` could be defaulted.
-- If we ditched support for YAML we could use Forge's own JSON encoder and keep the deps a bit simpler.
 - When testing with server you need to:
   - update `run/eula.txt`
   - in `run/server.properties` set `online-mode=false`

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,6 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
     // dependencies specific to `cinemashow` code
-    cinemashow 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
     cinemashow 'org.apache.commons:commons-text:1.10.0'
 
     // required for IDE
@@ -208,8 +207,9 @@ task runGenerateTextures (type: JavaExec) {
 // `copyExtraDepsToBuild` (along with `gatherExtraDeps`) extracts and copies the `cinemashow`
 // dependencies into the build path so that they will be included in the MOD jar.
 // TODO:
-// I'm unfamiliar with both build MC mods and the gradle system but what I've done feels pretty
-// hacky. Look into a more idiomatic way of structuring of structuring this deployment.
+// We no longer don't need to do this as the `commons-text` dependency is only required for
+// `runData`. I'm leaving it in for now as data generation will occasionally not find `commons-text`
+// and I haven't worked out why.
 
 task gatherExtraDeps(type: Copy) {
     group = customTaskGroup
@@ -235,7 +235,6 @@ task copyExtraDepsToBuild {
 }
 
 copyExtraDepsToBuild.dependsOn gatherExtraDeps
-jar.dependsOn copyExtraDepsToBuild
 
 task usefulDebug {
     group = customTaskGroup

--- a/src/main/java/uk/me/msb/cinemashow/gentextures/GenerateTextures.java
+++ b/src/main/java/uk/me/msb/cinemashow/gentextures/GenerateTextures.java
@@ -1,6 +1,5 @@
 package uk.me.msb.cinemashow.gentextures;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mojang.logging.LogUtils;
 import org.slf4j.Logger;
 import uk.me.msb.cinemashow.ShowProperties;
@@ -9,9 +8,7 @@ import javax.imageio.ImageIO;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -29,7 +26,7 @@ public class GenerateTextures {
     /**
      * The expected file name of the YAML file for the show's properties.
      */
-    public static final String METADATA_FILENAME = "meta.yaml";
+    public static final String METADATA_FILENAME = "meta.json";
 
     /**
      * The image format type of the output textures
@@ -144,7 +141,7 @@ public class GenerateTextures {
         }
 
         // Save the updated `ShowProperties` as a resource (to be available in-game, etc)
-        String metadataResourceName = String.format("%s.yaml", props.getAssignToBlock());
+        String metadataResourceName = String.format("%s.json", props.getAssignToBlock());
         props.save(new File(assetsDir, metadataResourceName));
     }
 
@@ -213,7 +210,9 @@ public class GenerateTextures {
         File metadataFile = new File(
                 texturesDir, String.format("%s.%s.mcmeta", outputFileName, FORMAT_TYPE)
         );
-        (new ObjectMapper()).writeValue(metadataFile, props.getMcmeta());
+        try (Writer writer = new FileWriter(metadataFile)) {
+            writer.write(props.getMcmeta());
+        }
     }
 
     public static void main(String[] args) {

--- a/src/main/java/uk/me/msb/cinemashow/setup/Registration.java
+++ b/src/main/java/uk/me/msb/cinemashow/setup/Registration.java
@@ -50,7 +50,7 @@ public class Registration {
 
         // check each block name for any show metadata resource files and populate `SHOW_PROPERTIES`
         for (ScreenBlockName name: ScreenBlockName.values()) {
-            String resource = String.format("/assets/%s/%s.yaml", MODID, name);
+            String resource = String.format("/assets/%s/%s.json", MODID, name);
             InputStream metadata = name.getClass().getResourceAsStream(resource);
             if (metadata != null) {
                 try {


### PR DESCRIPTION
Swapped to having the show properties encoded as JSON instead of YAML. This means we can reduce the dependencies by swapping Jackson with MCF's default Gson as the JSON encoder. This seems a good trade-off as show properties aren't complex (not much to be gained from YAML).

Also implemented sensible defaults for `frameTime`, `blocksX` and `blocksY`.
